### PR TITLE
Add double-sigmoid selectivity, enforced allometric mortality slope, and some exploratory segments. 

### DIFF
--- a/R/addEcopathCatchTotal.R
+++ b/R/addEcopathCatchTotal.R
@@ -1,27 +1,49 @@
 #' Sets up gear parameters from Ecopath catch data
 #'
-#' Uses the Catch data frame exported by Ecopath to set up gear parameters.
-#' Currently this sets up only a single gear for the total catch. The
-#' `yield_observed` gear parameter is set to the total catch for each species.
-#' The `catchability` is set to the ratio of the observed yield to the observed
-#' biomass. The selectivity of the gear is set to be sigmoidal with 50% of
-#' fish selected at maturity size and 25% selected at 90% of maturity size
-#' (measured in weight). Fishing is turned on with an initial effort of 1. The
-#' result will therefore not be at steady state yet.
+#' Uses the Catch data frame exported by Ecopath to set up gear parameters for a
+#' simplified "total" gear across all fleets. The `yield_observed` gear parameter
+#' is set to the total catch for each species, and `catchability` is initially set
+#' to the ratio of yield to biomass. This provides a starting point for fishing
+#' pressure, but does not yet ensure steady-state or matched yield.
 #'
-#' The catchability set by this function for each gear will be an
-#' underestimation of the catchability needed to produce the observed yield
-#' because setting it to the ratio of the observed yield to the observed biomass
-#' neglects that some of the biomass will be at sizes that are not fully
-#' selected by the gear. You will need to call `matchCatch()` to adjust the
-#' catchability to match the observed yield.
+#' The selectivity function is specified via the `sel_func` argument:
 #'
-#' @param params A MizerParams object
+#' * If `sel_func = "sigmoid_length"` (default), gear selectivity is a classic
+#'   sigmoidal function based on body length. The 50% selection point is set at
+#'   maturity size (`w_mat`), and 25% selection occurs at 90% of maturity size
+#'   (measured in weight).
+#'
+#' * If `sel_func = "double_sigmoid_length"`, a dome-shaped selectivity curve is
+#'   used. This is the product of two sigmoidal functions: one rising (as above)
+#'   and one falling. The descending limb reaches 50% selectivity at the species'
+#'   maximum length (`Length`) and 25% selectivity at 110% of that length. This
+#'   pattern reflects fishing that avoids very large individuals (e.g. due to
+#'   gear selectivity or behaviour).
+#'
+#' In both cases, fishing is switched on with an initial effort of 1. However, the
+#' result is not guaranteed to be at steady state, and catchability will generally
+#' need further adjustment. You should call `matchCatch()` to refine catchability
+#' and match the observed Ecopath yields.
+#'
+#' @details
+#' The `sel_func` argument specifies the form of the length-based selectivity function:
+#'
+#' * `"sigmoid_length"` (default): Classic sigmoidal selectivity based on length, with 50% selectivity at maturity length (`w_mat`) and 25% at 90% of that length (measured in weight).
+#'
+#' * `"double_sigmoid_length"`: A bell-shaped (dome-shaped) selectivity curve constructed by multiplying two sigmoid functions. The first sigmoid rises to 50% selection at maturity length (`w_mat`) and reaches 25% selection at 90% of that length. The second sigmoid falls, reaching 50% selection at the maximum observed length (`Length`) and 25% at 110% of that length. This mimics fisheries that avoid very large individuals (e.g. due to escape or avoidance behaviour).
+#'
+#' When `sel_func = "double_sigmoid_length"`, the additional columns `l50_right` and `l25_right` are automatically added to the gear parameters, and are calculated from `species_params$Length`.
+
+#'
+#' @param params A [`MizerParams`] object created with species parameters, typically including output from `addEcopathParams()`.
 #' @param ecopath_catch The Ecopath Catch data frame
+#' @param sel_func A string indicating the selectivity function to use. Either `"sigmoid_length"` (default) or `"double_sigmoid_length"`.
+
 #' @return A MizerParams object with gear parameters set up and fishing effort
 #'   switched on.
+#' @seealso [matchCatch()], [gear_params()]
 #' @export
-addEcopathCatchTotal <- function(params, ecopath_catch) {
+addEcopathCatchTotal <- function(params, ecopath_catch, sel_func = "sigmoid_length") {
     sp <- params@species_params
     if (!hasName(sp, "ecopath_groups") ||
         !hasName(sp, "biomass_observed")) {
@@ -31,13 +53,41 @@ addEcopathCatchTotal <- function(params, ecopath_catch) {
     gp <- data.frame(
         species = sp$species,
         gear = "total",
-        sel_func = "sigmoid_length",
+        sel_func = sel_func,
         l50 = w2l(sp$w_mat, params),
         l25 = w2l(sp$w_mat, params) * 0.9,
         # catchability and yield_observed will be extracted from Ecopath later
         catchability = 0,
         yield_observed = 0
     )
+
+    # Only add dome-shaped columns if requested
+    if (sel_func == "double_sigmoid_length") {
+        # Prefer observed max length if available, otherwise fall back to Lmax
+        ref_len <- if ("max_observed_length" %in% names(sp)) {
+            sp$max_observed_length
+        } else {
+            sp$Length
+        }
+        # 50% drop-off at ref_len; 25% at 110% of it
+        gp$l50_right <- ref_len
+        gp$l25_right <- ref_len * 1.1
+
+        # Catch edge case where dome would flatten (right limb slope ≤ 0)
+        bad <- gp$l25_right <= gp$l50_right
+        if (any(bad)) {
+            warning("addEcopathCatchTotal(): Flattened dome for: ",
+                    paste(gp$species[bad], collapse = ", "),
+                    "; nudging l25_right to avoid zero slope.")
+            gp$l25_right[bad] <- gp$l50_right[bad] * 1.001
+        }
+
+    } else {
+        # For single sigmoid: explicitly omit the dome columns
+        gp$l50_right <- NA
+        gp$l25_right <- NA
+    }
+
     # Extract total yield for each species from Ecopath
     for (i in seq_len(nrow(sp))) {
         for (group in sp$ecopath_groups[[i]]) {

--- a/R/fillDefaultsFromFishBase.R
+++ b/R/fillDefaultsFromFishBase.R
@@ -1,0 +1,130 @@
+#' Fill Species Traits Using FishBase
+#'
+#' Populates key life-history traits in a data frame of species using FishBase, via the `rfishbase` package.
+#'
+#' This function is typically used early in model setup, to populate a table of species names with biological parameters needed for Mizer models. It supports cases where only species names and scientific names are initially known.
+#'
+#' @param species_params A data frame containing at least a column with scientific names for each species. Other
+#' columns (e.g. common names or user-defined identifiers) may be included and will be preserved. This is
+#' typically a minimal table created at the start of model construction (e.g., from a species list), not yet a
+#' full `species_params` object.
+#' @param scientific_name_col A string giving the column name in `species_params` that holds the scientific names.
+#'   Defaults to `"Scientific_name"`.
+#' @param overwrite Logical (default = `FALSE`). If `TRUE`, existing values in the data frame are replaced by FishBase values.
+#'   If `FALSE`, only missing values are filled.
+#' @param verbose Logical (default = `TRUE`). If `TRUE`, prints a summary of filled species.
+#'
+#' @return The same data frame, augmented with the following columns where data are available:
+#' \itemize{
+#'   \item \code{a}, \code{b}: Length–weight allometric coefficients
+#'   \item \code{Length}: Maximum length (cm)
+#'   \item \code{w_max}: Maximum weight (calculated from Length, a, and b)
+#'   \item \code{l_mat}: Length at maturity (median)
+#'   \item \code{age_mat}: Age at maturity (median)
+#'   \item \code{w_mat}: Weight at maturity (from l_mat, a, and b)
+#' }
+#'
+#' @details
+#' This is a convenience function that queries FishBase through the `rfishbase` package.
+#' Traits are pulled from the `estimate()`, `maturity()`, and `species()` tables. Maturity traits
+#' are summarised by median within FishBase `SpecCode` groups. Derived weights are calculated from
+#' length–weight relationships.
+#'
+#' Existing columns in the input will only be overwritten if `overwrite = TRUE`.
+#'
+#' @note Requires the `rfishbase` package. Install it with `install.packages("rfishbase")`.
+#'
+#' @seealso [rfishbase::estimate()], [rfishbase::maturity()], [rfishbase::species()]
+#'
+#' @examples
+#' \dontrun{
+#' # Minimal example with only scientific names
+#' species_df <- data.frame(
+#'   Scientific_name = c("Merluccius merluccius", "Scomber scombrus")
+#' )
+#' enriched <- fillDefaultsFromFishBase(species_df)
+#'
+#' # Optional: include user-defined species labels
+#' species_df <- data.frame(
+#'   species = c("Hake", "Mackerel"),
+#'   Scientific_name = c("Merluccius merluccius", "Scomber scombrus")
+#' )
+#' enriched <- fillDefaultsFromFishBase(species_df)
+#' }
+#'
+#' @export
+
+fillDefaultsFromFishBase <- function(species_params,
+                                     scientific_name_col = "Scientific_name",
+                                     overwrite = FALSE,
+                                     verbose = TRUE) {
+
+    stopifnot(is.data.frame(species_params))
+    stopifnot(scientific_name_col %in% names(species_params))
+
+    if (!requireNamespace("rfishbase", quietly = TRUE)) {
+        stop("The 'rfishbase' package is required but not installed. Please install it with install.packages('rfishbase') to use this function.")
+    }
+
+    sci_names <- species_params[[scientific_name_col]]
+
+    # Get SpecCode mapping
+    spec_codes <- rfishbase::species(sci_names, fields = c("Species", "SpecCode"))
+    names(spec_codes)[1] <- scientific_name_col  # Rename to match input frame
+
+    # Merge SpecCode into species_params
+    species_params <- dplyr::left_join(species_params, spec_codes, by = scientific_name_col)
+
+    # Pull traits with SpecCode
+    length_weight <- rfishbase::estimate(sci_names)
+    maturity <- rfishbase::maturity(sci_names)
+    species_info <- rfishbase::species(sci_names, fields = c("SpecCode", "Length"))
+
+    # Summarise maturity by SpecCode (not Species!)
+    maturity_summary <- maturity |>
+        dplyr::filter(!is.na(tm), !is.na(Lm)) |>
+        dplyr::group_by(SpecCode) |>
+        dplyr::summarise(
+            age_mat = median(tm, na.rm = TRUE),
+            l_mat = median(Lm, na.rm = TRUE),
+            .groups = "drop"
+        )
+
+    # Merge all FishBase traits by SpecCode
+    fish_traits <- length_weight |>
+        dplyr::inner_join(species_info, by = "SpecCode") |>
+        dplyr::left_join(maturity_summary, by = "SpecCode") |>
+        dplyr::mutate(
+            w_max = a * Length^b,
+            w_mat = a * l_mat^b
+        )
+
+    # Join FishBase traits into main species_params
+    species_params <- dplyr::left_join(
+        species_params,
+        fish_traits,
+        by = "SpecCode",
+        suffix = c("", ".fb")
+    )
+
+    # Fill columns conditionally
+    cols <- c("a", "b", "Length", "l_mat", "age_mat", "w_max", "w_mat")
+    for (col in cols) {
+        filled <- paste0(col, ".fb")
+        if (filled %in% names(species_params)) {
+            species_params[[col]] <- ifelse(
+                overwrite | is.na(species_params[[col]]),
+                species_params[[filled]],
+                species_params[[col]]
+            )
+            species_params[[filled]] <- NULL
+        }
+    }
+
+    if (verbose) {
+        n_filled <- sum(!is.na(species_params$w_max))
+        message("FishBase values filled for ", n_filled, " species.")
+    }
+
+    return(species_params)
+}

--- a/R/matchCatch.R
+++ b/R/matchCatch.R
@@ -1,17 +1,23 @@
-#' Match the observed catch and yield
+#' Match observed catch, yield and production with a double‑sigmoid selectivity
 #'
-#' This function adjusts various model parameters for the selected species so
-#' that the model in steady state reproduces the observed catch size
+#' This function adjusts the gear‐selectivity and mortality parameters for one
+#' species so that a steady‑state model reproduces the observed catch size
 #' distribution, the observed yield and the observed production, if available.
 #'
 #' Currently this function is implemented only for the case where there is a
 #' single gear catching each species.
 #'
-#' The function sets new values for the following parameters:
-#' * `l50`: The size at which the gear selectivity is 50%.
-#' * `l25`: The size at which the gear selectivity is 25%.
-#' * `catchability`: The catchability of the gear.
-#' * `mu_mat`: The external mortality at maturity.
+#' A *double‑sigmoid* (dome‑shaped) selectivity function is used, as in
+#' `mizer::double_sigmoid_length()`.  Four key points define the curve:
+#'
+#' `l50` – length at 50 % *ascending* selectivity
+#' `l25` – length at 25 % *ascending* selectivity (`ratio = l25 / l50`, < 1)
+#' `l50_right` – length at 50 % *descending* selectivity
+#' `l25_right` – length at 25 % *descending* selectivity
+#' (`r_right = l25_right / l50_right`, > 1)
+#'
+#' When `l50_right == l50` *and* `r_right == 1`, the curve collapses to the
+#' ordinary single‑sigmoid.
 #'
 #' Only the parameters of the selected species are adjusted. The function then
 #' recalculates the corresponding rate arrays in the params object. It sets the
@@ -53,7 +59,7 @@
 #' the gradients. These are then passed to the `nlminb` function to minimize the
 #' objective function.
 #'
-#' @param params A MizerParams object
+#' @param params A `MizerParams` object
 #' @param species The species for which to match the catch. Optional. By default
 #'   all target species are selected. A vector of species names, or a numeric
 #'   vector with the species indices, or a logical vector indicating for each
@@ -87,6 +93,10 @@
 #' @export
 matchCatch <- function(params, species = NULL, catch, lambda = 2.05,
                        yield_lambda = 1, production_lambda = 1) {
+    # Accept count or catch as input
+    if (!"count" %in% names(catch) && "catch" %in% names(catch)) {
+        catch$count <- catch$catch
+    }
     species <- valid_species_arg(params, species = species,
                                  error_on_empty = TRUE)
     params <- validParams(params)
@@ -113,8 +123,13 @@ matchCatch <- function(params, species = NULL, catch, lambda = 2.05,
     sps <- sp[sp_select, ]
     gps <- gp[gp$species == species, ]
 
+    use_double_sigmoid <- identical(gps$sel_func, "double_sigmoid_length")
+
     mat_idx <- sum(params@w < sps$w_mat)
     w_mat <- params@w[mat_idx]
+    # ── upper bound on mu_mat so juvenile slope < community spectrum ──
+    g_mat     <- getEReproAndGrowth(params)[sp_select, mat_idx]
+    mu_mat_max <- g_mat / w_mat * (lambda - sps$n)
     if (!"mu_mat" %in% names(sps) || is.na(sps$mu_mat)) {
         # determine external mortality at maturity
         mu_mat <- ext_mort(params)[sp_select, mat_idx]
@@ -122,36 +137,74 @@ matchCatch <- function(params, species = NULL, catch, lambda = 2.05,
         mu_mat <- sps$mu_mat
     }
 
-    # Initial parameter estimates
-    initial_params <- c(l50 = gps$l50, ratio = gps$l25 / gps$l50,
-                        mu_mat = mu_mat,
-                        # we need non-zero catchability to match catch
-                        catchability = max(gps$catchability, 1e-8))
+    ## ---- New parameterisation: optimise l50, ratio, Δ50, r_right, mu_mat, catchability ----
 
-    # Set parameter bounds
-    # Mortality is bounded by the requirement that the juvenile spectrum of
-    # each species must be less steep than the community spectrum.
-    # With g(w) = g w^n and mu(w) = mu w^{n-1}, the exponent of the juvenile
-    # spectrum is -mu/g-n. The exponent of the community spectrum is -lambda.
-    g_mat <- getEReproAndGrowth(params)[sp_select, mat_idx]
-    mu_mat_max <- g_mat / w_mat * (lambda - sps$n)
-    lower_bounds <- c(l50 = 5, ratio = 0.1, mu_mat = 0.2,
-                      catchability = 1e-8)
-    upper_bounds <- c(l50 = Inf, ratio = 0.99, mu_mat = mu_mat_max,
-                      catchability = Inf)
+ # a) Build the initial parameter vector. Δ50 = l50_right - l50  (always > 0)
+    initial_params <- list(
+        l50          = gps$l50,
+        ratio        = gps$l25 / gps$l50,
+        d50          = gps$l50_right - gps$l50,
+        mu_mat       = mu_mat,
+        catchability = pmax(gps$catchability, 1e-8),
+        r_right      = gps$l25_right / gps$l50_right
+    )
 
-    map <- list()
-    if (!data$use_counts) {
-        map$l50 <- factor(NA)
-        map$ratio <- factor(NA)
-        lower_bounds <- lower_bounds[-(1:2)]
-        upper_bounds <- upper_bounds[-(1:2)]
+            # b) One simple, global bounds list
+    default_bounds <- list(
+        l50          = c(5,  Inf),
+        ratio        = c(0.1, 0.8),
+        d50          = c(5,  80),
+        mu_mat       = c(0.2, mu_mat_max),
+        catchability = c(1e-8, Inf),
+        r_right      = c(1.3, 4)
+    )
+
+                # For single‐sigmoid we still *pass* these parameters to TMB,
+                    # but give them a small, finite value in the dome‐shaped code
+                    if (!use_double_sigmoid) {
+                          initial_params["d50"]        <- default_bounds$d50[1]       # 10
+                          initial_params["r_right"]<- default_bounds$r_right[1] # 1.1
+                        }
+
+        lower_bounds <- sapply(default_bounds, `[`, 1)
+        upper_bounds <- sapply(default_bounds, `[`, 2)
+    if (getOption("mizerEcopath.debug.matchCatch", FALSE)) {
+        message("\nDEBUG: Optim bounds for ", species, ":\n")
+        print(data.frame(lower = lower_bounds, upper = upper_bounds))
     }
+
+    # Lock parameters where necessary
+    map <- list()
+
+    # Lock right-hand sigmoid parameters if using single sigmoid
+    if (!use_double_sigmoid) {
+        map$d50         <- factor(NA)
+        map$r_right <- factor(NA)
+        keep <- !names(lower_bounds) %in% c("d50", "r_right")
+        lower_bounds <- lower_bounds[keep]
+        upper_bounds <- upper_bounds[keep]
+    }
+
+
+    # Lock all selectivity parameters if no catch size data
+    if (!data$use_counts) {
+        map$l50         <- factor(NA)
+        map$ratio       <- factor(NA)
+        map$d50         <- factor(NA)
+        map$r_right <- factor(NA)
+        keep <- !names(lower_bounds) %in% c("l50", "ratio", "d50", "r_right")
+        lower_bounds <- lower_bounds[keep]
+        upper_bounds <- upper_bounds[keep]
+    }
+
+    # Lock catchability if yield not to be matched
     if (data$yield_lambda == 0) {
         map$catchability <- factor(NA)
-        lower_bounds <- lower_bounds[-4]
-        upper_bounds <- upper_bounds[-4]
+        keep <- names(lower_bounds) != "catchability"
+        lower_bounds <- lower_bounds[keep]
+        upper_bounds <- upper_bounds[keep]
     }
+
     # Prepare the objective function.
     obj <- MakeADFun(data = data,
                      parameters = initial_params,

--- a/R/newAllometricParams.R
+++ b/R/newAllometricParams.R
@@ -7,9 +7,9 @@
 #' The metabolic respiration rate, the feeding level and the reproduction level
 #' are set to zero.
 #'
-#' If the exponent `n` of the power-law encounter rate is not provided as a
-#' species parameter, it is set to 0.7. If the exponent `d` of the power-law
-#' mortality rate is not provided, it is set to `n - 1`.
+#' If the exponent n of the power-law encounter rate is not provided as a species
+#' parameter, it is set to 0.7. The exponent d of the power-law mortality rate is
+#' *always* imposed as n - 1, regardless of any supplied value.
 #'
 #' If the species parameter `alpha`, which gives the proportion of the consumption
 #' that is assimilated, is not provided, it is set to 0.8, the default value
@@ -17,8 +17,9 @@
 #'
 #' The coefficient of the power-law encounter rate for each species is chosen so
 #' that the species grows to maturity size by its maturity age. The coefficient
-#' of the power-law mortality rate is chosen so that the juvenile biomass
-#' density has a slightly negative slope (of 0.5).
+#' of the power-law mortality rate is computed from the growth rate (using
+#' `getEGrowth()`), and is chosen so that the#' juvenile biomass density has a
+#' slightly negative slope.
 #'
 #' The species uses `matchGrowth()` to adjust the encounter rate coefficient to
 #' produce the desired growth rate. It uses `matchBiomasses()` to match the
@@ -37,7 +38,7 @@ newAllometricParams <- function(species_params, no_w = 200) {
 
     # Impose relation between exponents
     sp <- set_species_param_default(sp, "n", 0.7)
-    sp <- set_species_param_default(sp, "d", sp$n - 1)
+    sp$d <- sp$n - 1
 
     # Set default assimilation efficiency
     sp <- set_species_param_default(sp, "alpha", 0.8)
@@ -74,7 +75,7 @@ newAllometricParams <- function(species_params, no_w = 200) {
     factor <- age_mat(p) / sp$age_mat
     ext_encounter(p) <- sweep(ext_encounter(p), 1, factor, "*")
     # Determine power-law coefficient for encounter rate
-    e0 <- getEncounter(p)[, 1] / w(p)[1] ^ sp$n[1]
+    e0 <- getEGrowth(p)[, 1] / w(p)[1] ^ sp$n[1]
 
     # Set power-law mortality
     # Choose a positive coefficient so that the juvenile biomass density

--- a/R/update_params.R
+++ b/R/update_params.R
@@ -1,70 +1,75 @@
 #' Function that updates params object with new parameter values
 #'
-#' This function currently updates the gear selectivity parameters `l50` and
-#' `l25, the catchability, the steepness `U` of the maturity ogive and the
-#' coefficient `M` of the power-law mortality rate. It then recalculates the
-#' steady state of the model and rescales it to match the observed biomass.
+#' This function updates the gear selectivity parameters `l50`, `l25`,
+#' the descending distance `d50` from `l50` to `l50_right`, the catchability,
+#' the steepness `U` of the maturity ogive and the coefficient `M` of the
+#' power-law mortality rate. It then recalculates the steady state of the model
+#' and rescales it to match the observed biomass.
 #'
-#' @param params The MizerParams object to update
-#' @param species The species to update. By default the first species in the
-#'   model.
-#' @param pars A named numeric vector of parameter values
-#' @param data The list with data as passed to the objective function
-#' @param w_select A logical vector indicating which weight bins were used in
-#'   the likelihood calculation
-#' @return The updated MizerParams object
+#' @param params A MizerParams object to update.
+#' @param species The species to update (index, name, or logical).
+#' @param pars A named numeric vector of parameter values from `matchCatch`.
+#' @param data The list of data passed to the objective function.
+#' @param w_select A logical vector of weight bins used in the likelihood.
+#' @return The updated MizerParams object.
 #' @export
 update_params <- function(params, species = 1, pars, data, w_select) {
     params <- validParams(params)
+
+    # Ensure new selectivity columns exist
+    if (!"l50_right" %in% names(params@gear_params))
+        params@gear_params$l50_right <- NA_real_
+    if (!"l25_right" %in% names(params@gear_params))
+        params@gear_params$l25_right <- NA_real_
+
     sp <- species_params(params)
-
-    # Need to add mu_mat column if it does not exist
-    # TODO: change once we have introduced a standard species param for this
+    # Ensure mu_mat column exists
     mat_idx <- colSums(outer(params@w, sp$w_mat, "<"))
-    mu_mat <- ext_mort(params)[cbind(seq_len(nrow(sp)), mat_idx)]
-    params <- set_species_param_default(params, "mu_mat", mu_mat)
+    mu_mat_default <- ext_mort(params)[cbind(seq_len(nrow(sp)), mat_idx)]
+    params <- set_species_param_default(params, "mu_mat", mu_mat_default)
 
+    # Validate single species
     species <- valid_species_arg(params, species, error_on_empty = TRUE)
-    if (length(species) > 1) {
-        stop("Only one species can be updated at a time.")
-    }
+    if (length(species) > 1) stop("Only one species can be updated at a time.")
 
+    # Subset for this species
     sp_select <- sp$species == species
     sps <- sp[sp_select, ]
-
     gp <- params@gear_params
     gp_select <- gp$species == species
     gps <- gp[gp_select, ]
-    if (nrow(gps) > 1) {
-        stop("The code currently assumes that there is only a single gear for each species.")
-    }
+    if (nrow(gps) > 1) stop("Only one gear per species is currently supported.")
 
-    # Update the gear parameters
+    # Update parameters from optimizer
     if (data$use_counts) {
+        # ascending selectivity
         gps$l50 <- pars["l50"]
         gps$l25 <- pars["ratio"] * pars["l50"]
+        # descending distance from l50
+        d50 <- pars["d50"]
+        gps$l50_right <- pars["l50"] + abs(d50)
+        gps$l25_right <- pars["r_right"] * gps$l50_right
     }
+    # catchability
     if (data$yield_lambda > 0) {
         gps$catchability <- pars["catchability"]
     }
-    gear_params(params)[gp_select, ] <- gps
 
-    # recalculate the power-law mortality rate
+    # Write back gear_params
+    gp[gp_select, ] <- gps
+    params@gear_params <- gp
+
+    # Update external mortality at maturity
     sps$mu_mat <- pars["mu_mat"]
-    # Note that `mu_mat` is the mortality at the w just below w_mat
     mat_idx <- sum(params@w < sps$w_mat)
     w_mat <- params@w[mat_idx]
-    ext_mort(params)[sp_select, ] <-
-        pars["mu_mat"] * (params@w / w_mat)^sps$d
-
+    ext_mort(params)[sp_select, ] <- pars["mu_mat"] * (params@w / w_mat)^sps$d
     params@species_params[sp_select, ] <- sps
-    params <- setReproduction(params)
 
-    # Calculate the new steady state ----
+    # Recompute reproduction, steady state, and rescale biomass
+    params <- setReproduction(params)
     params <- steadySingleSpecies(params)
-    # Rescale it to get the observed biomass
-    total <- sum(params@initial_n[sp_select, w_select] *
-                     params@w[w_select] * params@dw[w_select])
+    total <- sum(params@initial_n[sp_select, w_select] * params@w[w_select] * params@dw[w_select])
     factor <- data$biomass / total
     params@initial_n[sp_select, ] <- params@initial_n[sp_select, ] * factor
     params <- setBevertonHolt(params, reproduction_level = 0)

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,1 +1,2 @@
 mizerEcopath.dll
+objective_function.dll

--- a/src/objective_function.cpp
+++ b/src/objective_function.cpp
@@ -1,20 +1,31 @@
 #include <TMB.hpp>
 
-// Helper function: Fishing mortality
+// Helper: double‑sigmoid fishing mortality
 template<class Type>
-vector<Type> calculate_F_mort(Type l50, Type ratio, Type catchability,
-                              vector<Type> l)
+vector<Type> calculate_F_mort(Type  l50_left,   Type ratio_left,
+                              Type  l50_right,  Type r_right,
+                              Type  catchability,
+                              const vector<Type> &l)
 {
-    Type c1 = Type(1.0);
-    Type sr = l50 * (c1 - ratio);
-    Type s1 = l50 * log(Type(3.0)) / sr;
-    Type s2 = s1 / l50;
+    const Type one  = Type(1.0);
+    const Type LOG3 = log(Type(3.0));
 
-    vector<Type> F_mort = catchability / (c1 + exp(s1 - s2 * l));
+    /* ---- Rising limb  ---- */
+    Type sr_left = l50_left * (one - ratio_left);        // l50 - l25
+    Type s1_left = l50_left * LOG3 / sr_left;
+    Type s2_left = s1_left / l50_left;
+    vector<Type> sel_left = one / (one + exp(s1_left - s2_left * l));
 
-    // Ensure all elements are finite and >= 0
+    /* ---- Falling limb ----
+    r_right  > 1   →  sr_right < 0   →  negative slope */
+    Type sr_right = l50_right * (one - r_right);
+    Type s1_right = l50_right * LOG3 / sr_right;
+    Type s2_right = s1_right / l50_right;
+    vector<Type> sel_right = one / (one + exp(s1_right - s2_right * l));
+
+    vector<Type> F_mort = catchability * sel_left.cwiseProduct(sel_right);
+
     TMBAD_ASSERT((F_mort.array().isFinite() && (F_mort.array() >= 0)).all());
-
     return F_mort;
 }
 
@@ -64,14 +75,21 @@ Type objective_function<Type>::operator() ()
     DATA_SCALAR(production_lambda); // Penalty strength for production deviation
 
     // **Parameter Section**
-    PARAMETER(l50);          // Length at 50% gear selectivity
-    PARAMETER(ratio);        // Ratio between l25 and l50
+    PARAMETER(l50);          // Length at 50% gear selectivity (ascending limb)
+    PARAMETER(ratio);        // Ascending steepness: l25 / l50  (<1)
+    PARAMETER(d50);          // New: distance from l50 up to descending 50% point
     PARAMETER(mu_mat);       // Mortality at maturity size
     PARAMETER(catchability); // Catchability
+    PARAMETER(r_right);  // Descending steepness: l25_right / l50_right (>1)
+
+    // Reconstruct the actual right‐hand 50% point to guarantee that l50_right > l50 even if the optimiser tries a     negative d50
+    Type l50_right = l50 + CppAD::abs(d50);
+
 
     // **Calculate fishing mortality rate**
-    vector<Type> F_mort = calculate_F_mort(l50, ratio, catchability, l);
-
+    vector<Type> F_mort = calculate_F_mort(l50,       ratio,
+                                           l50_right, r_right,
+                                           catchability, l);
     // **Calculate total mortality rate**
     vector<Type> mort = mu_mat * pow(w / w_mat, d) + F_mort;
 
@@ -109,7 +127,8 @@ Type objective_function<Type>::operator() ()
 
         // Multinomial negative log-likelihood
         // You might or might not want to divide by counts.sum()—that’s up to you.
-        nll -= dmultinom(counts, probs, true) / counts.sum();
+        // nll -= dmultinom(counts, probs, true) / counts.sum() original version for reference
+        nll -= dmultinom(counts, probs, true);
     }
     // else: skip all calculations involving 'counts'
 

--- a/tests/Exploring Natural Mortality Estimation.Rmd
+++ b/tests/Exploring Natural Mortality Estimation.Rmd
@@ -1,0 +1,629 @@
+---
+title: "Exploring Natural Mortality Estimation"
+output:
+  html_document:
+    toc: true
+    toc_depth: 2
+    number_sections: true
+    theme: united
+    highlight: tango
+  pdf_document:
+    toc: true
+    toc_depth: '2'
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = TRUE, warning = FALSE, message = FALSE)
+```
+
+# Load Packages
+
+Below we load all required libraries and the package under development (`mizerEcopath`).
+
+```{r load-packages}
+# devtools::document()
+# TMB::compile("src/objective_function.cpp")
+# dyn.load(TMB::dynlib("src/objective_function"))
+# devtools::load_all()    # loads mizerEcopath
+library(rfishbase)         # for FishBase look-ups
+library(dplyr)
+library(here)
+library(mizer)
+library(mizerExperimental)
+library(ggplot2)
+library(tidyr)
+library(rlang) 
+library(RColorBrewer)
+devtools::load_all()
+```
+
+# Pick Species
+
+We define the set of species to test, assign plotting colours, and create a lookup table of common vs. scientific names.
+
+```{r pick-species}
+# Select species for testing
+species_test <- c("Hake", "Mackerel", "Blue whiting")
+
+# Assign colours based on number of species
+n_species <- length(species_test)
+cols <- if (n_species < 3) {
+  # Use base colours if 1 or 2 species
+  c("firebrick", "steelblue", "darkgreen")[1:n_species]
+} else {
+  RColorBrewer::brewer.pal(n = n_species, name = "Dark2")
+}
+
+# Full lookup table with common and scientific names
+species_map_all <- data.frame(
+  species         = c("Hake", "Mackerel", "Blue whiting"),
+  Scientific_name = c("Merluccius merluccius",
+                      "Scomber scombrus",
+                      "Micromesistius poutassou"),
+  stringsAsFactors = FALSE
+)
+
+# Filter just the species you want to test
+species_map <- species_map_all %>%
+  filter(species %in% species_test)
+```
+
+# Pull FishBase Defaults
+
+We call `fillDefaultsFromFishBase()` to retrieve parameters (e.g., `w_max`, `w_mat`, `a`, `b`, `age_mat`) from FishBase for each species, then set additional Mizer-specific defaults.
+
+```{r fishbase-defaults}
+fb <- fillDefaultsFromFishBase(species_map, overwrite = FALSE, verbose = FALSE)
+
+sp <- fb %>%
+  select(species, w_max, w_mat, a, b, age_mat, Length) %>%
+  mutate(
+    n = 0.7,
+    p = 0.7,
+    d = -0.3,
+    alpha = 0.8
+  )
+```
+
+# Minimal Ecopath “Basic Estimates” Table
+
+We create a minimal Ecopath table with biomass, consumption, and production rates for our test species. In practice, these values would come from a full Ecopath model or published source.
+
+```{r ecopath-table}
+ecopath_basic_all <- data.frame(
+  `...1`                             = 1:3,
+  `Group name`                       = c("Blue whiting", "Hake", "Mackerel"),
+  `Biomass (t/km²)`                  = c(0.444, 0.260, 15.653),
+  `Consumption / biomass (/year)`    = c(6.666, 3.529, 1.730),
+  `Production / consumption (/year)` = c(0.165, 0.312, 0.376),
+  check.names = FALSE                # keep the Unicode ² intact
+)
+
+ecopath_basic <- ecopath_basic_all |>
+  filter(`Group name` %in% species_test)
+
+```
+
+# Map Model Species to Ecopath Groups
+
+We construct a named list mapping Mizer species names to Ecopath group names. In this simple example they coincide.
+
+```{r map-species-to-groups}
+species_to_groups <- as.list(fb$species)
+names(species_to_groups) <- fb$species
+```
+
+# Prepare `species_params` & Add Ecopath Info
+
+We finalise the species parameter table by computing weight-at-maturity from FishBase and then injecting Ecopath biomass, consumption, and production.
+
+```{r prepare-species-params}
+sp <- sp %>%
+  mutate(
+    w_max = a * Length^b,
+    w_mat = w_mat,
+    w_repro_max = w_max,
+    n     = 0.7,
+    p     = 0.7,
+    alpha = 0.8
+  )
+
+sp <- addEcopathParams(sp, ecopath_basic, species_to_groups)
+```
+
+# Build a Non‐interacting Allometric Model
+
+Here we create a new Mizer parameter object (`params`) with no trophic interactions. This will serve as the baseline before adding catch and selectivity.
+
+```{r build-base-model}
+params <- newAllometricParams(sp, no_w = 200)   # steady state
+```
+
+# Add Hand‐made Total Catch Data
+
+We define a simple data frame of total catch (tonnes per km² per year) for each species. In a full application, this would come from observed landings or surveys.
+
+```{r add-catch-data}
+catch_df <- data.frame(
+  `Group name`                = sp$species,
+  `TotalCatch (t/km²/year)`   = c(0.3, 0.1, 0.5),
+  check.names = FALSE
+)
+
+```
+
+# Add Double‐sigmoid (Dome‐shaped) Selectivity Gear
+
+We attach double‐sigmoid selectivity (`double_sigmoid_length`), which combines ascending and descending logistic limbs to produce a dome-shaped curve.
+
+```{r dome-sigmoid-gear}
+params_dome <- addEcopathCatchTotal(
+  params,
+  catch_df,
+  sel_func = "double_sigmoid_length"
+)
+```
+
+# Combined Procedure: Load Observed Catch, Run Matching & Compare
+
+We now load observed catch-at-length data, which serves as the empirical benchmark for estimating selectivity and natural mortality parameters. Two models are calibrated:
+
+A single-sigmoid selectivity case (logistic curve), and a double-sigmoid (dome-shaped) case, allowing for decreasing vulnerability at large sizes — more biologically realistic for some gears or species.
+
+The matchCatch() function then fits model-predicted catch length frequencies to these observed data, balancing production, yield, and catch constraints. These initial calibrations provide both a baseline for comparison and a foundation for sensitivity analysis.
+
+```{r match-catch-procedure}
+# Load Observed Catch Data
+landings_total <- readRDS(here("tests", "catch_with_observer.rds"))
+
+landings_total <- landings_total %>%
+  mutate(
+    dl = 1,
+    gear = ifelse(gear == "commercial", "total", gear),
+    species = ifelse(species == "Horse Mackerel", "Horse mackerel", species)
+  ) %>%
+  filter(gear == "total") %>%
+  group_by(species, length) %>%
+  summarise(dl = first(dl), count = sum(catch), .groups = "drop") %>%
+  filter(species %in% species_test) %>%
+  arrange(species, length)
+
+# Single‐sigmoid: match catch, yield, production
+params_ss <- addEcopathCatchTotal(params, catch_df, sel_func = "sigmoid_length")
+params_ss_mc <- params_ss %>%
+  matchGrowth() %>%
+  steadySingleSpecies() %>%
+  matchBiomasses() %>%
+  matchCatch(catch = landings_total)
+
+# Double‐sigmoid: match catch, yield, production (with lower penalties)
+params_ds_mc <- params_dome %>%
+  matchGrowth() %>%
+  steadySingleSpecies() %>%
+  matchBiomasses() %>%
+  matchCatch(
+    catch = landings_total,
+    yield_lambda      = 0.25,
+    production_lambda = 0.25
+  )
+```
+
+# sensitivity-grid-deterministic
+To investigate the robustness of parameter estimation, we perform a structured deterministic grid search over six key starting parameters:
+
+Selectivity shape - l50, d50, dome width (ratio), and right-hand steepness of the dome (r_right), catchability, and natural mortality at maturity (mu_mat).
+
+Each parameter is perturbed using 3 multiplier levels, producing a full factorial grid of 3^6 = 729 runs. For each run, matchCatch() is called using the perturbed starting values.
+
+The goal is to identify:
+Whether results converge consistently across starting values.
+Which parameters or combinations drive optimiser failure or instability.
+Whether the objective surface has a single global minimum or contains ridges and plateaus.
+
+```{r sensitivity-grid-deterministic, warning=FALSE, message=FALSE}
+# ————————————————————————————————
+# 1. Define function to run matchCatch from given starts
+# ————————————————————————————————
+run_matchCatch_with_start <- function(params, species, catch, start_vals) {
+  sp_row <- species_params(params) %>% filter(species == !!species)
+  gp_row <- gear_params(params)   %>% filter(species == !!species)
+
+  par0 <- list(
+    l50          = gp_row$l50        * start_vals["l50_mult"],
+    ratio        = (gp_row$l25 / gp_row$l50) * start_vals["ratio_mult"],
+    d50          = (gp_row$l50_right - gp_row$l50) * start_vals["d50_mult"],
+    mu_mat       = ifelse(is.na(sp_row$mu_mat),
+                          ext_mort(params)[sp_row$species == species, which.min(abs(w(params) - sp_row$w_mat))],
+                          sp_row$mu_mat) * start_vals["mu_mat_mult"],
+    catchability = pmax(gp_row$catchability * start_vals["catchability_mult"], 1e-8),
+    r_right      = (gp_row$l25_right / gp_row$l50_right) * start_vals["r_right_mult"]
+  )
+
+  par0 <- lapply(par0, function(x) ifelse(is.finite(x), x, 1))
+
+  obj <- try(TMB::MakeADFun(
+    data       = prepare_data(params, species = species, catch = catch,
+                              yield_lambda = 0.25, production_lambda = 0.25),
+    parameters = par0,
+    DLL        = "mizerEcopath",
+    silent     = TRUE
+  ), silent = TRUE)
+
+  if (inherits(obj, "try-error")) return(NULL)
+
+  opt <- try(nlminb(start = obj$par, objective = obj$fn, gradient = obj$gr), silent = TRUE)
+
+  if (!inherits(opt, "try-error") && is.finite(opt$objective)) {
+    return(list(opt = opt, par = opt$par, objective = opt$objective))
+  }
+
+  return(NULL)
+}
+
+# ————————————————————————————————
+# 2. Prepare data & base parameters
+# ————————————————————————————————
+# Choose the species to analyse here
+target_species <- "Hake"
+
+# 'params_ds_mc' and 'landings_total' should exist from previous chunks:
+#   params_ds_mc <- params_dome %>% matchGrowth() %>% steadySingleSpecies() %>% matchBiomasses() %>% matchCatch(...)
+#   landings_total <- readRDS(...) %>% preprocess(...)
+# We assume they have been created already.
+
+
+# ————————————————————————————————
+# 3. Build a deterministic “multiplier grid”
+# ————————————————————————————————
+# We choose 3 equally‐spaced multipliers for each parameter:
+#   * For gear‐related: 0.8, 1.0, 1.2
+#   * For mu_mat and catchability: 0.5, 1.0, 2.0
+grid_df <- expand.grid(
+  l50_mult          = c(0.8, 1.0, 1.2),
+  ratio_mult        = c(0.8, 1.0, 1.2),
+  d50_mult          = c(0.8, 1.0, 1.2),
+  mu_mat_mult       = c(0.5, 1.0, 2.0),
+  catchability_mult = c(0.5, 1.0, 2.0),
+  r_right_mult      = c(0.8, 1.0, 1.2),
+  stringsAsFactors  = FALSE
+)
+# This yields 3^6 = 729 deterministic starting combinations.
+
+# ————————————————————————————————
+# 4. Loop over the grid and collect results
+# ————————————————————————————————
+results_det <- lapply(seq_len(nrow(grid_df)), function(i) {
+  start_vals <- as.numeric(grid_df[i, ])
+  names(start_vals) <- names(grid_df)
+  run_matchCatch_with_start(
+    params        = params_ds_mc,
+    species       = target_species,
+    catch         = landings_total,
+    start_vals    = start_vals
+  )
+})
+
+# ————————————————————————————————
+# 5. Summarise & plot convergence diagnostics
+# ————————————————————————————————
+finite_runs <- Filter(Negate(is.null), results_det)
+cat("Total grid points:           ", nrow(grid_df), "\n")
+cat("Successful (finite‐objective) runs:", length(finite_runs), "\n\n")
+
+if (length(finite_runs) > 0) {
+  # Extract negative log‐likelihoods
+  obj_vals <- sapply(finite_runs, `[[`, "objective")
+
+  # Compute Q₁, Q₃, IQR, and “upper fence” = Q₃ + 2 × IQR
+  Q1          <- quantile(obj_vals, 0.25)
+  Q3          <- quantile(obj_vals, 0.75)
+  IQR_val     <- Q3 - Q1
+  upper_fence <- Q3 + 2 * IQR_val
+
+  # Label runs as “Outlier” if objective > upper fence
+  is_outlier <- obj_vals > upper_fence
+  status     <- ifelse(is_outlier, "Outlier", "Good")
+
+  # Sort by objective for plotting
+  sorted_idx  <- order(obj_vals)
+  sorted_vals <- obj_vals[sorted_idx]
+  sorted_col  <- ifelse(status[sorted_idx] == "Outlier", "red", "blue")
+
+  plot(seq_along(sorted_vals), sorted_vals,
+       pch = 19, col = sorted_col,
+       xlab = "Grid point (sorted)", 
+       ylab = "Negative log-likelihood",
+       main = paste0("Sensitivity of matchCatch to Starting Values (", 
+                     target_species, ")"))
+  abline(h = min(obj_vals), col = "darkgreen", lwd = 2)
+  abline(h = upper_fence, col = "darkorange", lwd = 2, lty = 2)
+
+  legend("topleft",
+         legend = c("Good run", "Outlier run", "Best fit (min Obj)", "Upper fence = Q3 + 2×IQR"),
+         col    = c("blue", "red", "darkgreen", "darkorange"),
+         pch    = c(19, 19, NA, NA),
+         lty    = c(NA, NA, 1, 2),
+         lwd    = c(NA, NA, 2, 2),
+         bty    = "n")
+} else {
+  cat("No finite‐objective runs to summarise.\n")
+}
+```
+
+# inspect-outlier-properties
+Once all grid runs are completed, we assess which parameter combinations lead to poor fits. We define "outlier" runs as those with objective values above the upper fence (Q3 + 2 × IQR), and visualise how these outliers are distributed across the parameter multipliers.
+
+This helps answer:
+
+Which parameters (or combinations) are associated with failure to converge or poor likelihood values?
+
+Are some parameters well-tolerated across ranges, while others cause breakdowns?
+
+Do any axes in parameter space appear especially sensitive or problematic?
+
+```{r inspect-outlier-properties}
+# 1. Extract objective values and classify outliers
+obj_vals <- sapply(finite_runs, `[[`, "objective")
+Q1 <- quantile(obj_vals, 0.25)
+Q3 <- quantile(obj_vals, 0.75)
+IQR_val <- Q3 - Q1
+upper_fence <- Q3 + 2 * IQR_val
+is_outlier <- obj_vals > upper_fence
+
+# 2. Match result indices back to original grid
+finite_indices <- which(!sapply(results_det, is.null))
+non_outlier_grid_indices <- finite_indices[!is_outlier]
+outlier_grid_indices     <- finite_indices[is_outlier]
+
+# 3. Create tidy dataframe of starting values and outcome
+param_df <- grid_df[c(non_outlier_grid_indices, outlier_grid_indices), ]
+param_df$objective <- obj_vals
+param_df$outlier   <- rep(c("Good", "Outlier"),
+                          times = c(length(non_outlier_grid_indices), length(outlier_grid_indices)))
+
+# 4. Pivot to long format for plotting
+library(tidyr)
+plot_df <- param_df %>%
+  pivot_longer(cols = ends_with("_mult"), names_to = "parameter", values_to = "multiplier")
+
+# 5. Plot: Faceted bar plots (accurate discrete counts)
+ggplot(plot_df, aes(x = factor(multiplier), fill = outlier)) +
+  geom_bar(position = "dodge") +
+  facet_wrap(~parameter, scales = "free", ncol = 3) +
+  scale_fill_manual(values = c("Good" = "skyblue", "Outlier" = "red")) +
+  labs(title = "Starting Parameter Distributions by Run Type",
+       x = "Multiplier",
+       y = "Count",
+       fill = "Run type") +
+  theme_minimal(base_size = 12)
+
+```
+# profile-mu-mat
+We next conduct a 1D profile likelihood analysis for mu_mat, the external natural mortality rate at maturity.
+
+Keeping all other parameters fixed at plausible defaults, we vary mu_mat over a defined range and evaluate the objective function at each value.
+
+This plot provides insight into:
+
+Whether natural mortality is  identifiable from catch-at-length data alone
+
+Whether the likelihood is flat (indicating structural non-identifiability) or sharply peaked
+
+Where the model finds its best fit, and how sensitive it is to small changes in mu_mat
+
+```{r profile-mu-mat}
+# Profile the objective function over mu_mat, holding other parameters fixed
+
+# Choose target species
+target_species <- "Hake"
+
+# Set a grid of multipliers to apply to default mu_mat
+mu_profile_grid <- seq(0.05, 0.4, length.out = 25)
+
+# Use the "best known" default parameters from params_ds_mc
+sp_row <- species_params(params_ds_mc) %>% filter(species == target_species)
+gp_row <- gear_params(params_ds_mc)   %>% filter(species == target_species)
+
+# Extract the base values (not multipliers)
+default_pars <- list(
+  l50          = gp_row$l50,
+  ratio        = gp_row$l25 / gp_row$l50,
+  d50          = gp_row$l50_right - gp_row$l50,
+  catchability = gp_row$catchability,
+  r_right      = gp_row$l25_right / gp_row$l50_right
+)
+
+# Set up results
+mu_profile_results <- data.frame(mu_mult = mu_profile_grid,
+                                 mu_value = NA,
+                                 objective = NA)
+
+# Loop through grid
+for (i in seq_along(mu_profile_grid)) {
+  mu_mult <- mu_profile_grid[i]
+
+  # Calculate mu_mat value
+  mu_val <- ifelse(is.na(sp_row$mu_mat),
+                   ext_mort(params_ds_mc)[target_species, which.min(abs(w(params_ds_mc) - sp_row$w_mat))],
+                   sp_row$mu_mat) * mu_mult
+
+  # Create par0 using fixed defaults for others
+  par0 <- list(
+    l50          = default_pars$l50,
+    ratio        = default_pars$ratio,
+    d50          = default_pars$d50,
+    mu_mat       = mu_val,
+    catchability = pmax(default_pars$catchability, 1e-8),
+    r_right      = default_pars$r_right
+  )
+
+  # Ensure finite
+  par0 <- lapply(par0, function(x) ifelse(is.finite(x), x, 1))
+
+  # Prepare objective
+  data_obj <- prepare_data(params_ds_mc,
+                           species = target_species,
+                           catch = landings_total,
+                           yield_lambda = 0.25,
+                           production_lambda = 0.25)
+  obj <- TMB::MakeADFun(data = data_obj,
+                        parameters = par0,
+                        DLL = "mizerEcopath",
+                        silent = TRUE)
+
+  opt <- try(nlminb(start = obj$par,
+                    objective = obj$fn,
+                    gradient  = obj$gr,
+                    lower = rep(-Inf, length(obj$par)),
+                    upper = rep( Inf, length(obj$par))),
+             silent = TRUE)
+
+  if (!inherits(opt, "try-error") && is.finite(opt$objective)) {
+    mu_profile_results$mu_value[i]   <- mu_val
+    mu_profile_results$objective[i]  <- opt$objective
+  }
+}
+
+# Plot the profile
+library(ggplot2)
+ggplot(mu_profile_results, aes(x = mu_value, y = objective)) +
+  geom_line(col = "steelblue", lwd = 1.2) +
+  geom_point(col = "steelblue", size = 2) +
+  labs(title = paste0("Objective Profile over mu_mat (", target_species, ")"),
+       x = "mu_mat (external mortality at maturity)",
+       y = "Negative log-likelihood") +
+  theme_minimal()
+```
+
+# profile-mu-mat-by-ratio-sorted
+To explore parameter confounding, we expand the profile into two dimensions: mu_mat × ratio, where ratio controls the width and severity of the dome in the double-sigmoid gear.
+
+For each combination in the 2D grid:
+
+All other parameters are held constant.
+
+matchCatch() is re-evaluated and the objective value recorded.
+
+This panel-style plot reveals:
+
+Whether there is a ridge (i.e., a trade-off) between mu_mat and dome width
+
+Whether the model compensates for high natural mortality with steep domes, or vice versa
+
+Regions of parameter space that produce equally good fits, despite differing biological implications
+
+This is helpful for diagnosing unidentifiable parameter combinations.
+
+```{r profile-mu-mat-by-ratio-sorted, warning=FALSE, message=FALSE}
+# ------------------------------------------------------------------------------
+# Profile objective over mu_mat × ratio — matchCatch sensitivity panel-style plot
+# This chunk mimics the earlier "starting value sensitivity" plot but uses a 2D
+# grid across natural mortality and selectivity ratio.
+# ------------------------------------------------------------------------------
+
+# Setup grid
+ratio_vals <- c(0.6, 0.8, 1.0, 1.2, 1.4, 1.6)
+mu_vals    <- seq(0.005, 0.03, length.out = 25)
+
+# Extract reference parameters
+sp_row <- species_params(params_ds_mc) %>% filter(species == target_species)
+gp_row <- gear_params(params_ds_mc)   %>% filter(species == target_species)
+
+default_pars <- list(
+  l50          = gp_row$l50,
+  d50          = gp_row$l50_right - gp_row$l50,
+  catchability = gp_row$catchability,
+  r_right      = gp_row$l25_right / gp_row$l50_right
+)
+
+base_mu <- ifelse(is.na(sp_row$mu_mat),
+                  ext_mort(params_ds_mc)[target_species, which.min(abs(w(params_ds_mc) - sp_row$w_mat))],
+                  sp_row$mu_mat)
+
+# Build grid
+prof_df <- expand.grid(mu_mult = mu_vals, ratio_mult = ratio_vals)
+prof_df$mu_val    <- base_mu * prof_df$mu_mult
+prof_df$objective <- NA_real_
+
+# Evaluate
+for (i in seq_len(nrow(prof_df))) {
+  row <- prof_df[i, ]
+  par0 <- list(
+    l50          = default_pars$l50,
+    ratio        = row$ratio_mult,
+    d50          = default_pars$d50,
+    mu_mat       = row$mu_val,
+    catchability = default_pars$catchability,
+    r_right      = default_pars$r_right
+  )
+  par0 <- lapply(par0, function(x) ifelse(is.finite(x), x, 1))
+
+try_result <- try({
+  obj <- TMB::MakeADFun(
+    data       = prepare_data(params_ds_mc, species = target_species, catch = landings_total,
+                              yield_lambda = 0.25, production_lambda = 0.25),
+    parameters = par0,
+    DLL        = "mizerEcopath",
+    silent     = TRUE
+  )
+  
+  if (!is.finite(obj$fn(obj$par))) stop("Non-finite objective")
+  
+  opt <- nlminb(start = obj$par, objective = obj$fn, gradient = obj$gr)
+  
+  if (is.finite(opt$objective)) {
+    prof_df$objective[i] <- opt$objective
+  }
+}, silent = TRUE)
+
+}
+
+# Classify outliers per ratio group
+prof_valid <- prof_df %>%
+  filter(!is.na(objective)) %>%
+  mutate(ratio_mult = factor(ratio_mult, levels = ratio_vals))
+
+get_sorted_status <- function(sub_df) {
+  objs <- sub_df$objective
+  Q1 <- quantile(objs, 0.25)
+  Q3 <- quantile(objs, 0.75)
+  IQR_val <- Q3 - Q1
+  upper_fence <- Q3 + 2 * IQR_val
+  best_val <- min(objs)
+  status <- ifelse(objs > upper_fence, "Outlier", "Good")
+  sorted_idx <- order(objs)
+
+  data.frame(
+    ratio_mult   = sub_df$ratio_mult[1],
+    sorted_index = seq_along(sorted_idx),
+    objective    = objs[sorted_idx],
+    status       = status[sorted_idx],
+    best_val     = best_val,
+    upper_fence  = upper_fence
+  )
+}
+
+plot_df <- prof_valid %>%
+  group_by(ratio_mult) %>%
+  group_map(~ get_sorted_status(.x), .keep = TRUE) %>%
+  bind_rows()
+
+# Plot like matchCatch diagnostic
+ggplot(plot_df, aes(x = sorted_index, y = objective, colour = status)) +
+  geom_point(size = 1.5) +
+  facet_wrap(~ ratio_mult, scales = "free_y", ncol = 3) +
+  geom_hline(aes(yintercept = best_val), colour = "darkgreen", linetype = "solid", size = 0.8) +
+  geom_hline(aes(yintercept = upper_fence), colour = "darkorange", linetype = "dashed", size = 0.8) +
+  scale_colour_manual(values = c("Good" = "blue", "Outlier" = "red")) +
+  labs(
+    title = paste0("Sensitivity of matchCatch to mu_mat × ratio (", target_species, ")"),
+    subtitle = "Outliers above Q3 + 2×IQR per panel",
+    x = "Run (sorted within ratio_mult)",
+    y = "Negative log-likelihood",
+    colour = "Run type"
+  ) +
+  theme_minimal(base_size = 12) +
+  theme(legend.position = "bottom")
+
+```
+NEED TO CONSIDER HOW TO SPECIFY VALID RATIO OPTIONS BETTER

--- a/tests/testthat/test-addEcopathCatchTotal.R
+++ b/tests/testthat/test-addEcopathCatchTotal.R
@@ -1,0 +1,78 @@
+# tests/testthat/test-addEcopathCatchTotal.R
+test_that("addEcopathCatchTotal sets gear params with sigmoid_length", {
+    sp <- data.frame(
+        species          = "TestFish",
+        w_max            = 1e4,
+        w_mat            = 100,
+        a                = 0.01,
+        b                = 3,
+        age_mat          = 2,
+        Length           = 50,
+        biomass_observed = 500,
+        stringsAsFactors = FALSE
+    )
+
+    ecop <- data.frame(
+        `...1`                            = 1,
+        `Group name`                      = "GroupA",
+        `Biomass (t/km²)`                 = 500,
+        `Consumption / biomass (/year)`   = 5,
+        `Production / consumption (/year)`= 1,
+        stringsAsFactors = FALSE
+    )
+
+    sp <- addEcopathParams(sp, ecop, list(TestFish = "GroupA"))
+    params <- newAllometricParams(sp)
+
+    catch_df <- data.frame(
+        `Group name`              = "GroupA",
+        `TotalCatch (t/km²/year)` = 100,
+        stringsAsFactors          = FALSE
+    )
+    p <- addEcopathCatchTotal(params, catch_df, sel_func = "sigmoid_length")
+
+    gp <- gear_params(p)
+    expect_equal(unique(gp$sel_func), "sigmoid_length")
+    expect_true(all(c("l50", "l25") %in% names(gp)))
+    expect_false(any(c("l50_right", "l25_right") %in% names(gp)))
+})
+
+test_that("addEcopathCatchTotal sets gear params with double_sigmoid_length", {
+    sp <- data.frame(
+        species          = "TestFish",
+        w_max            = 1e4,
+        w_mat            = 100,
+        a                = 0.01,
+        b                = 3,
+        age_mat          = 2,
+        Length           = 50,
+        biomass_observed = 500,
+        stringsAsFactors = FALSE
+    )
+
+    ecop <- data.frame(
+        `...1` = 1,
+        `Group name` = "GroupA",
+        `Biomass (t/km²)` = 500,
+        `Consumption / biomass (/year)` = 5,
+        `Production / consumption (/year)` = 1,
+        stringsAsFactors = FALSE
+    )
+
+    sp <- addEcopathParams(sp, ecop, list(TestFish = "GroupA"))
+    params <- newAllometricParams(sp)
+
+    catch_df <- data.frame(
+        `Group name`              = "GroupA",
+        `TotalCatch (t/km²/year)` = 100,
+        stringsAsFactors          = FALSE
+    )
+
+    p2 <- addEcopathCatchTotal(params, catch_df, sel_func = "double_sigmoid_length")
+    gp2 <- gear_params(p2)
+
+    expect_equal(unique(gp2$sel_func), "double_sigmoid_length")
+    expect_true(all(c("l50_right", "l25_right") %in% names(gp2)))
+    expect_equal(gp2$l50_right, 50)
+    expect_equal(gp2$l25_right, 50 * 1.1)
+})

--- a/tests/testthat/test-fillDefaultsFromFishBase.R
+++ b/tests/testthat/test-fillDefaultsFromFishBase.R
@@ -1,0 +1,61 @@
+test_that("fillDefaultsFromFishBase fills missing values", {
+    df <- data.frame(
+        species = c("Hake", "Mackerel"),
+        Scientific_name = c("Merluccius merluccius", "Scomber scombrus"),
+        w_max = NA,
+        stringsAsFactors = FALSE
+    )
+
+    filled <- fillDefaultsFromFishBase(df)
+
+    expect_true(all(!is.na(filled$w_max)))
+    expect_true("a" %in% names(filled))
+    expect_true("age_mat" %in% names(filled))
+})
+
+
+test_that("fillDefaultsFromFishBase respects overwrite argument", {
+    df <- data.frame(
+        species = "Hake",
+        Scientific_name = "Merluccius merluccius",
+        a = 999,  # fake wrong value
+        w_max = NA,
+        stringsAsFactors = FALSE
+    )
+
+    # Should leave 'a' as 999
+    filled_no_overwrite <- fillDefaultsFromFishBase(df, overwrite = FALSE)
+    expect_equal(filled_no_overwrite$a, 999)
+
+    # Should replace 'a' with real FishBase value
+    filled_with_overwrite <- fillDefaultsFromFishBase(df, overwrite = TRUE)
+    expect_true(filled_with_overwrite$a != 999)
+})
+
+
+test_that("fillDefaultsFromFishBase handles species not in FishBase", {
+    df <- data.frame(
+        species = "UnknownFish",
+        Scientific_name = "Fictitious imaginarius",
+        w_max = NA,
+        stringsAsFactors = FALSE
+    )
+
+    filled <- fillDefaultsFromFishBase(df, verbose = FALSE)
+    expect_true(is.na(filled$w_max))  # Should remain NA
+    expect_true("a" %in% names(filled))  # a should still be present
+})
+
+
+test_that("fillDefaultsFromFishBase works with a custom scientific name column", {
+    df <- data.frame(
+        species = "Mackerel",
+        sci_name = "Scomber scombrus",
+        w_max = NA,
+        stringsAsFactors = FALSE
+    )
+
+    filled <- fillDefaultsFromFishBase(df, scientific_name_col = "sci_name")
+    expect_true(!is.na(filled$w_max))
+    expect_true("a" %in% names(filled))
+})

--- a/tests/testthat/test-setAllometricParams.R
+++ b/tests/testthat/test-setAllometricParams.R
@@ -1,0 +1,62 @@
+test_that("juvenile biomass spectrum slope is near -0.2 for default parameters", {
+    # Set up a simple species parameter data frame for a single species
+    sp <- data.frame(
+        species = "TestFish",
+        w_max = 1000,        # maximum weight
+        w_mat = 100,         # weight at maturity
+        n = 0.7,             # default consumption exponent
+        a = 0.01,            # dummy parameter for length-weight relationship
+        b = 3,               # dummy parameter for length-weight relationship
+        age_mat = 5,
+        Length = 50
+    )
+
+    # Create the model parameters with newAllometricParams
+    p <- newAllometricParams(sp, no_w = 200)
+
+    # Get the weight grid from MizerParams
+    w <- p@w
+
+    # Extract the abundance distribution
+    N <- as.numeric(initialN(p))
+
+    # Calculate biomass density as abundance multiplied by weight
+    B <- N * w
+
+    # Define the juvenile range (weights less than w_mat)
+    juvenile <- w < p@species_params$w_mat[p@species_params$species == "TestFish"]
+
+    # Log-transform the values and fit a linear model
+    log_w <- log(w[juvenile])
+    log_B <- log(B[juvenile])
+    fit <- lm(log_B ~ log_w)
+    slope <- coef(fit)["log_w"]
+
+    # Check that the fitted slope is near -0.2 (with a tolerance of 0.1)
+    expect_equal(as.numeric(slope), -0.2, tolerance = 0.1)
+})
+
+test_that("mortality exponent d is forced to equal n - 1", {
+    # Create a species parameter data frame with an intentionally wrong d value
+    sp <- data.frame(
+        species = "TestFish",
+        w_max = 1000,
+        w_mat = 100,
+        n = 0.65,            # non-default n
+        a = 0.01,
+        b = 3,
+        age_mat = 5,
+        Length = 50,
+        d = 42               # bogus d value that should be overridden
+    )
+
+    # Create the model parameters
+    p <- newAllometricParams(sp, no_w = 200)
+
+    # Extract the enforced mortality exponent from the model
+    actual_d <- p@species_params$d[p@species_params$species == "TestFish"]
+    expected_d <- p@species_params$n[p@species_params$species == "TestFish"] - 1
+
+    # Test that the forced relationship holds
+    expect_equal(actual_d, expected_d)
+})


### PR DESCRIPTION
This PR aims to enhance the mizerEcopath framework with new functionality for dome-shaped gear selectivity and more robust parameter handling. Contributions include:

1. Double-sigmoid (dome-shaped) selectivity support
Adds a double_sigmoid_length selectivity function to model dome-shaped fishing mortality curves.

Parameters include:

l50, ratio (as before),

new: d50 (width to l50_right) and r_right (steepness of descending limb).

Implemented in both gear parameter setup and TMB objective function (calculate_F_mort()), ensuring compatibility with matchCatch().

2. Automatic enforcement of allometric mortality slope
Modifies newAllometricParams() to automatically force the allometric mortality exponent:

d = n - 1

Ensures internal consistency between consumption scaling and mortality scaling without requiring manual input.

Accompanied by unit tests checking:

Juvenile biomass spectrum slope ≈ -0.2 for default parameters.

That d is correctly forced to n - 1 even when an incorrect d is supplied.

3. Extended parameter update logic
Updates update_params() to:

Handle new selectivity parameters (l50_right, l25_right, d50, r_right).

Ensure missing defaults (e.g. mu_mat) are initialised safely.

Write back updated gear and species parameters, recalculate steady state, and rescale biomass.

Supports updated workflows for parameter estimation and identifiability testing.

4. New exploratory R Markdown workflow
Adds a .Rmd file titled:
"Exploring Natural Mortality Estimation"

Designed to investigate whether natural mortality can be well-estimated from the available data. 

