### PR TITLE
Don't always match everything

### DIFF
--- a/R/tuneParams_helpers.R
+++ b/R/tuneParams_helpers.R
@@ -57,9 +57,9 @@ tuneParams_update_species <- function(sp, p, params, params_old) {
         p_old <- params_old()
         p@initial_n <- p_old@initial_n
 
-        p <- steadySingleSpecies(p)
-        p <- matchBiomasses(p)
-        p <- setBevertonHolt(p, reproduction_level = 0)
+        p <- steadySingleSpecies(p, species = sp)
+        p <- matchBiomasses(p, species = sp)
+        # p <- setBevertonHolt(p, reproduction_level = 0)
 
         # Update the reactive params object
         tuneParams_update_params(p, params)

--- a/R/tuneParams_helpers.R
+++ b/R/tuneParams_helpers.R
@@ -21,6 +21,8 @@ prepare_params <- function(p) {
     mu_mat <- ext_mort(p)[cbind(seq_len(no_sp), mat_idx)]
     p <- set_species_param_default(p, "mu_mat", mu_mat)
 
+    p <- steadySingleSpecies(p)
+    p <- matchBiomasses(p)
     return(p)
 }
 

--- a/man/tuneEcopath.Rd
+++ b/man/tuneEcopath.Rd
@@ -10,6 +10,7 @@ tuneEcopath(
   diet = NULL,
   controls = c("match", "fishing", "reproduction", "other", "exponent"),
   tabs = c("Spectra", "Catch", "Growth", "Repro", "Diet", "Death"),
+  match = c("none"),
   preserve = c("erepro", "reproduction_level", "R_max"),
   return_app = FALSE,
   ...
@@ -33,6 +34,11 @@ below.}
 
 \item{tabs}{A character vector of names of the tabs that should be displayed
 in the main section. See "Customisation" below.}
+
+\item{match}{A character vector. Determines which quantities should be
+matched to observations each time the "steady" button is pressed. Possible
+entries are \code{"growth"} (using \code{\link[=matchGrowth]{matchGrowth()}}), \code{"catch"} (using
+\code{\link[=matchCatch]{matchCatch()}}) and \code{"consumption"} (using \code{\link[=matchConsumption]{matchConsumption()}}).}
 
 \item{preserve}{Specifies whether the \code{reproduction_level} should be
 preserved or the maximum reproduction rate \code{R_max} or the reproductive


### PR DESCRIPTION
There are now checkboxes to determine what should be matched when pressing the "match" button. Only biomasses are always matched.
Also set to steady state and match biomasses when gadget is started. 
When changing parameters, only recalculate spectrum for currently selected species.