### PR TITLE
Fix diffusion feeding level

### DIFF
--- a/R/getDiffusion.R
+++ b/R/getDiffusion.R
@@ -83,7 +83,8 @@ getDiffusion <- function(params, n = initialN(params),
         stop("Fourier transform method not implemented for diffusion rate.")
     }
 
-    diffusion <- (1 - getFeedingLevel(params)) *
+    diffusion <- (1 - getFeedingLevel(params, n = n, n_pp = n_pp,
+                                      n_other = n_other, t = t)) *
         (params@species_params$alpha)^order * encounter
     return(diffusion)
 }

--- a/tests/testthat/test-getDiffusion-use-n.R
+++ b/tests/testthat/test-getDiffusion-use-n.R
@@ -1,0 +1,12 @@
+context("getDiffusion uses n argument")
+
+params <- setPredKernel(NS_params, pred_kernel = getPredKernel(NS_params))
+
+
+n_doubled <- initialN(params) * 2
+
+test_that("getDiffusion depends on n", {
+  d_default <- getDiffusion(params)
+  d_modified <- getDiffusion(params, n = n_doubled)
+  expect_false(identical(d_default, d_modified))
+})


### PR DESCRIPTION
## Summary
- ensure `getDiffusion` uses the passed abundance arguments when
  calculating feeding level
- add regression test

## Testing
- `devtools::test()` *(fails: R missing)*

------
https://chatgpt.com/codex/tasks/task_e_6873c89b5714832788be07e1960be052