### PR TITLE
Additional changes to catchability.

### DIFF
--- a/R/addCatch.R
+++ b/R/addCatch.R
@@ -84,7 +84,7 @@ addCatch <- function(params, landings, survey,step) {
     # Set fishing effort depending on step
     if (step == 1) {
         initial_effort(params)[unique(landings$gear)] <- 0
-        gear_params(params)$catchability<-1e-10
+        gear_params(params)$catchability<-1e-7
     } else if (step %in% c(2, 3)) {
         initial_effort(params)[unique(landings$gear)] <- 1
         gear_params(params)$catchability<-1

--- a/R/fishingControl.R
+++ b/R/fishingControl.R
@@ -30,7 +30,7 @@ fishingControl <- function(input, output, session, params, params_old,
         p@gear_params[gp_idx, "catchability"]  <- input$catchability
         updateSliderInput(session, "catchability",
                           min = signif(max(input$catchability / 2 - 1, 0), 2),
-                          max = signif(max(input$catchability * 2, 2), 2))
+                          max = signif(max(input$catchability * 2, 0.1), 2))
 
         if (p@gear_params[gp_idx, "sel_func"] == "knife_edge") {
             updateSliderInput(session, "knife_edge_size",
@@ -71,7 +71,7 @@ fishingControl <- function(input, output, session, params, params_old,
         updateSliderInput(session, "catchability",
                           value = catchability,
                           min = signif(max(catchability / 2 - 1, 0), 2),
-                          max = signif(max(catchability * 2, 2), 2))
+                          max = signif(max(catchability * 2, 0.1), 2))
 
         if (p@gear_params[gp_idx, "sel_func"] == "knife_edge") {
             knife_edge_size <- p@gear_params[gp_idx, "knife_edge_size"]
@@ -130,8 +130,8 @@ fishingControlUI <- function(params, input) {
                sliderInput("catchability", "Catchability",
                            value = gp$catchability,
                            min = signif(max(0, gp$catchability / 2 - 1), 5),
-                           max = signif(max(gp$catchability * 2, 2), 5),
-                           step = 0.00001)
+                           max = signif(max(gp$catchability * 2, 0.1), 5),
+                           step = 1e-6)
     )
 
     if (gp$sel_func == "knife_edge") {


### PR DESCRIPTION
Changes made to catchability to allow simulation of survey size distribution without imparting mortality on the size spectrum in tune ecopath. Had do set the catchability in add catch to e-7 rather than e-10 due to the fact that the slider becomes glitchy at very low values, additionally set the minimum maximum slider value to 0.1 rather than 0.25 to allow for catchability to be set to lower values without reaching 0.