### PR TITLE
Adding `max_w` argument in `newAllometricParams()`

### DIFF
--- a/R/newAllometricParams.R
+++ b/R/newAllometricParams.R
@@ -32,11 +32,18 @@
 #' `kappa = 10^11`. The exponent of the resource replenishment rate is
 #' set to `n = 0.7`.
 #'
+#' If you plan to fit several single-species models as a preliminary step
+#' to generating a multi-species model, it is necessary that the maximum
+#' weight of all species be the same. To achieve this, you must select the
+#' largest weight among all species in `max_w`.
+#'
 #' @param species_params A data frame with species parameters
 #' @param no_w The number of weight bins to use in the model
+#' @param max_w The maximum weight used to the model.
+#' Maximum fish weight by default.
 #' @return A MizerParams object
 #' @export
-newAllometricParams <- function(species_params, no_w = 200) {
+newAllometricParams <- function(species_params, no_w = 200, max_w = NULL) {
     sp <- validGivenSpeciesParams(species_params)
 
     # Impose relation between exponents
@@ -55,7 +62,16 @@ newAllometricParams <- function(species_params, no_w = 200) {
     # Generate a default mizer model with the desired species We extend the
     # resource spectrum over the entire size range to ensure that all species
     # have sufficient prey throughout their life.
-    max_w <- max(sp$w_max)
+
+    if(is.null(max_w)){ max_w <- max(sp$w_max)}
+
+    if( max_w < max(sp$w_max)){
+        warning("The maximum weight provided (max_w) is lower than the
+                maximum size of the fish. The model has been generated with
+                the latter")}
+
+    max_w <- max(max_w,sp$w_max)
+
     p <- newMultispeciesParams(sp, no_w = no_w, info_level = 0,
                                # extend resource over entire size range
                                max_w = max_w,

--- a/R/update_params.R
+++ b/R/update_params.R
@@ -63,6 +63,9 @@ update_params <- function(params, species = 1, pars, data) {
 
     gear_params(params)[gp_select, ] <- gps
 
+    # Getting the "m" value
+    sps$m <- pars[["m"]]
+
     # recalculate the power-law mortality rate
     sps$mu_mat <- pars[["mu_mat"]]
     # Note that `mu_mat` is the mortality at the w just below w_mat


### PR DESCRIPTION
Hi Gustav, 

I'm making this pull request in case you're interested in making this change, as I consider it necessary to be able to generate a multispecies model from several single-species models generated with this function.

It allows you to manually choose the maximum weight to be computed in the model, with an explanation of the motivation for doing so, as well as its default value (species_params$w_max). It also returns a warning if the manually selected weight is less than the value of species_params$w_max.

Best,
Anxo