### PR TITLE
Support second-order scheme in matchCatch

### DIFF
--- a/R/prepare_data.R
+++ b/R/prepare_data.R
@@ -221,10 +221,10 @@ prepare_data <- function(params, species = 1, catch,
     # Prepare data list for TMB
     if (second_order) {
         flux_limiter <- params@second_order_w[["flux"]]
-        psi_full <- mizer:::flux_limiter_psi(params, initialN(params), getEGrowth(params), flux_limiter)
-        psi <- psi_full[sp_select, w_select]
+        chi_full <- mizer:::flux_limiter_psi(params, initialN(params), getEGrowth(params), flux_limiter)
+        chi <- chi_full[sp_select, w_select]
     } else {
-        psi <- rep(0, length(w))
+        chi <- rep(0, length(w))
     }
 
     data <- list(
@@ -254,7 +254,7 @@ prepare_data <- function(params, species = 1, catch,
         n = n,
         w_repro_max = w_repro_max,
         second_order = as.integer(second_order),
-        psi = psi,
+        chi = chi,
         defaults_edition = mizer::defaults_edition(),
         b_lw = sps$b
     )

--- a/R/prepare_data.R
+++ b/R/prepare_data.R
@@ -41,6 +41,7 @@ prepare_data <- function(params, species = 1, catch,
     gp <- params@gear_params
     gp_select <- gp$species == species
     gps <- gp[gp_select, ]
+    second_order <- params@second_order_w[["flux"]] != "upwind"
 
     # Validate catch data frame and extract data for the selected species
     if (nrow(catch) == 0) {
@@ -143,7 +144,11 @@ prepare_data <- function(params, species = 1, catch,
         # thus its steady state. The catch likelihood still uses only the
         # observed bins (all <= w_max).
         w_max_idx <- sum(w <= sps$w_max)
-        w_max <- w[min(w_max_idx + 1L, length(w))]
+        if (second_order) {
+            w_max <- w[w_max_idx]
+        } else {
+            w_max <- w[min(w_max_idx + 1L, length(w))]
+        }
     }
 
     w <- w(params)
@@ -214,6 +219,14 @@ prepare_data <- function(params, species = 1, catch,
 
 
     # Prepare data list for TMB
+    if (second_order) {
+        flux_limiter <- params@second_order_w[["flux"]]
+        psi_full <- mizer:::flux_limiter_psi(params, initialN(params), getEGrowth(params), flux_limiter)
+        psi <- psi_full[sp_select, w_select]
+    } else {
+        psi <- rep(0, length(w))
+    }
+
     data <- list(
         use_counts = use_counts,
         counts = counts,
@@ -239,7 +252,11 @@ prepare_data <- function(params, species = 1, catch,
         matur = matur,
         ergr = ergr,
         n = n,
-        w_repro_max = w_repro_max
+        w_repro_max = w_repro_max,
+        second_order = as.integer(second_order),
+        psi = psi,
+        defaults_edition = mizer::defaults_edition(),
+        b_lw = sps$b
     )
 
     # The gears that are being matched, in the order used for `counts`, `yield`

--- a/R/update_params.R
+++ b/R/update_params.R
@@ -100,7 +100,12 @@ update_params <- function(params, species = 1, pars, data) {
     # the steady state below (which is diffusion-aware) uses the same diffusion
     # as the TMB objective.
     sps$D_ext <- exp(pars[["log_D_ext"]])
-    params@ext_diffusion[sp_select, ] <- sps$D_ext * params@w^(sps$n + 1)
+    if (isTRUE(params@second_order_w[["bin_average"]])) {
+        params@ext_diffusion[sp_select, ] <- sps$D_ext *
+            mizer:::power_law_bin_average(params@w, params@dw, sps$n + 1)
+    } else {
+        params@ext_diffusion[sp_select, ] <- sps$D_ext * params@w^(sps$n + 1)
+    }
 
     params@species_params[sp_select, ] <- sps
     params <- setReproduction(params)

--- a/src/objective_function.cpp
+++ b/src/objective_function.cpp
@@ -2,7 +2,8 @@
 
 template<class Type>
 vector<Type> calculate_F_mort(Type sel_func, Type logit_l50, Type log_ratio_left, Type log_l50_right_offset, Type log_ratio_right,
-                              Type log_catchability, vector<Type> L, Type min_len, Type max_len)
+                              Type log_catchability, vector<Type> L, Type min_len, Type max_len,
+                              vector<Type> w, vector<Type> dw, Type b_lw, int second_order)
 {
     Type l50 = min_len + (max_len - min_len) * invlogit(logit_l50);
     Type l25 = l50 * (1 - invlogit(log_ratio_left));
@@ -14,26 +15,67 @@ vector<Type> calculate_F_mort(Type sel_func, Type logit_l50, Type log_ratio_left
 
     vector<Type> F_mort(L.size());
 
+    // Setup for double sigmoid
+    Type l50_right = Type(0.0);
+    Type l25_right = Type(0.0);
+    Type sr_right = Type(0.0);
+    Type s1_right = Type(0.0);
+    Type s2_right = Type(0.0);
+
     if(sel_func == 1) {
-        Type l50_right = l50 + exp(log_l50_right_offset);
-        Type l25_right = l50_right * (1 + exp(log_ratio_right));
-        Type sr_right = l50_right - l25_right;
-        Type s1_right = l50_right * log(Type(3.0)) / sr_right;
-        Type s2_right = s1_right / l50_right;
+        l50_right = l50 + exp(log_l50_right_offset);
+        l25_right = l50_right * (1 + exp(log_ratio_right));
+        sr_right = l50_right - l25_right;
+        s1_right = l50_right * log(Type(3.0)) / sr_right;
+        s2_right = s1_right / l50_right;
+    }
 
+    if (second_order == 1) {
+        // Bin-averaged selectivity
+        int Q = 100;
         for (int i = 0; i < L.size(); i++) {
-            Type ilength = L(i);
-            Type sel = (Type(1.0) / (Type(1.0) + exp(s1 - s2 * ilength))) *
-                (Type(1.0) / (Type(1.0) + exp(s1_right - s2_right * ilength)));
-            F_mort(i) = catchability * sel;
+            Type w_val = w(i);
+            Type dw_val = dw(i);
+            Type beta = Type(1.0) + dw_val / w_val;
+            
+            Type sum_sel_w = Type(0.0);
+            Type sum_w = Type(0.0);
+            
+            for (int q = 1; q <= Q; q++) {
+                Type q_frac = (Type(q) - Type(0.5)) / Type(Q);
+                Type w_q = w_val * pow(beta, q_frac);
+                Type l_q = L(i) * pow(beta, q_frac / b_lw);
+                
+                Type sel = Type(0.0);
+                if (sel_func == 1) {
+                    sel = (Type(1.0) / (Type(1.0) + exp(s1 - s2 * l_q))) *
+                          (Type(1.0) / (Type(1.0) + exp(s1_right - s2_right * l_q)));
+                } else if (sel_func == 2) {
+                    sel = (Type(1.0) / (Type(1.0) + exp(s1 - s2 * l_q)));
+                }
+                
+                sum_sel_w += sel * w_q;
+                sum_w += w_q;
+            }
+            
+            F_mort(i) = catchability * (sum_sel_w / sum_w);
         }
+    } else {
+        // Point-sampled selectivity
+        if(sel_func == 1) {
+            for (int i = 0; i < L.size(); i++) {
+                Type ilength = L(i);
+                Type sel = (Type(1.0) / (Type(1.0) + exp(s1 - s2 * ilength))) *
+                    (Type(1.0) / (Type(1.0) + exp(s1_right - s2_right * ilength)));
+                F_mort(i) = catchability * sel;
+            }
 
-    } else if(sel_func == 2){
-
-        for (int i = 0; i < L.size(); i++) {
-            Type ilength = L(i);
-            Type sel = (Type(1.0) / (Type(1.0) + exp(s1 - s2 * ilength)));
-            F_mort(i) = catchability * sel;
+        } else if(sel_func == 2){
+            for (int i = 0; i < L.size(); i++) {
+                Type ilength = L(i);
+                Type sel = (Type(1.0) / (Type(1.0) + exp(s1 - s2 * ilength)));
+                F_mort(i) = catchability * sel;
+            }
         }
     }
 
@@ -42,7 +84,8 @@ vector<Type> calculate_F_mort(Type sel_func, Type logit_l50, Type log_ratio_left
 
 template<class Type>
 vector<Type> calculate_growth(vector<Type> w, vector<Type> ergr,
-                              vector<Type> matur, Type m, Type n, Type w_repro_max)
+                              vector<Type> matur, Type m, Type n, Type w_repro_max,
+                              int defaults_edition)
 {
     // Matches mizer's psi formula: repro_prop = pmin(1, (w/w_repro_max)^(m-n))
     // then psi = maturity * repro_prop, also capped at 1
@@ -54,7 +97,20 @@ vector<Type> calculate_growth(vector<Type> w, vector<Type> ergr,
     for (int i = 0; i < phi.size(); i++) {
         if (phi(i) > Type(1.0)) phi(i) = Type(1.0);
     }
+    
+    // Set psi for all w > w_repro_max to 1 if defaults_edition < 2
+    if (defaults_edition < 2) {
+        for (int i = 0; i < w.size(); i++) {
+            if (w(i) > w_repro_max) {
+                phi(i) = Type(1.0);
+            }
+        }
+    }
+    
     vector<Type> growth = (Type(1.0) - phi) * ergr;
+    for (int i = 0; i < growth.size(); i++) {
+        if (growth(i) < Type(0.0)) growth(i) = Type(0.0);
+    }
 
     return growth;
 }
@@ -109,6 +165,68 @@ vector<Type> calculate_N(vector<Type> mort, vector<Type> growth,
 }
 
 template<class Type>
+vector<Type> calculate_N_second_order(vector<Type> mort, vector<Type> growth,
+                                      vector<Type> dw, vector<Type> w, vector<Type> d, vector<Type> psi)
+{
+    int size = dw.size();
+    vector<Type> a(size), b(size), c(size), S(size);
+
+    // Spacing on the log-size grid
+    Type h = log(w(1) / w(0));
+    Type beta = w(1) / w(0);
+
+    // Egg boundary: N(0) is fixed to 1; the overall scale is normalised later.
+    a(0) = Type(0.0);
+    b(0) = Type(1.0);
+    c(0) = Type(0.0);
+    S(0) = Type(1.0);
+
+    for (int j = 1; j < size; ++j) {
+        Type inv_dw = Type(1.0) / dw(j);
+        
+        Type gj = growth(j);
+        Type psij = psi(j);
+        
+        Type gj_plus_1 = (j < size - 1) ? growth(j + 1) : growth(j);
+        Type psij_plus_1 = (j < size - 1) ? psi(j + 1) : Type(0.0);
+        
+        Type wj = w(j);
+        Type wj_plus_1 = (j < size - 1) ? w(j + 1) : w(j) * beta;
+        
+        Type dj = d(j);
+        Type dj_minus_1 = d(j - 1);
+        Type dj_plus_1 = (j < size - 1) ? d(j + 1) : d(j);
+
+        a(j) = -inv_dw * (gj * (Type(1.0) - Type(0.5) * psij) + dj_minus_1 / (Type(2.0) * h * wj));
+        
+        b(j) = mort(j) + inv_dw * (gj_plus_1 * (Type(1.0) - Type(0.5) * psij_plus_1) 
+                                   - Type(0.5) * psij * gj 
+                                   + dj * (Type(1.0) / (Type(2.0) * h * wj) + Type(1.0) / (Type(2.0) * h * wj_plus_1)));
+        
+        c(j) = (j < size - 1) ?
+            (inv_dw * (Type(0.5) * psij_plus_1 * gj_plus_1 - dj_plus_1 / (Type(2.0) * h * wj_plus_1))) : Type(0.0);
+            
+        S(j) = Type(0.0);
+    }
+
+    // Thomas algorithm (double sweep) for the tridiagonal system.
+    vector<Type> cp(size), sp(size), N(size);
+    cp(0) = c(0) / b(0);
+    sp(0) = S(0) / b(0);
+    for (int j = 1; j < size; ++j) {
+        Type denom = b(j) - a(j) * cp(j - 1);
+        cp(j) = c(j) / denom;
+        sp(j) = (S(j) - a(j) * sp(j - 1)) / denom;
+    }
+    N(size - 1) = sp(size - 1);
+    for (int j = size - 2; j >= 0; --j) {
+        N(j) = sp(j) - cp(j) * N(j + 1);
+    }
+
+    return N;
+}
+
+template<class Type>
 Type objective_function<Type>::operator() ()
 {
 
@@ -136,6 +254,10 @@ Type objective_function<Type>::operator() ()
     DATA_VECTOR(ergr);
     DATA_SCALAR(n);
     DATA_SCALAR(w_repro_max);
+    DATA_INTEGER(second_order);
+    DATA_VECTOR(psi);
+    DATA_INTEGER(defaults_edition);
+    DATA_SCALAR(b_lw);
 
     PARAMETER_VECTOR(logit_l50);
     PARAMETER_VECTOR(log_ratio_left);
@@ -161,7 +283,8 @@ Type objective_function<Type>::operator() ()
     for (int g = 0; g < n_g; ++g) {
         vector<Type> F_mort_g = calculate_F_mort(sel_func[g], logit_l50[g],
                                                  log_ratio_left[g], log_l50_right_offset[g],
-                                                                                        log_ratio_right[g], log_catchability[g], l, min_len, max_len);
+                                                 log_ratio_right[g], log_catchability[g], l, min_len, max_len,
+                                                 w, dw, b_lw, second_order);
         for (int i = 0; i < n_bins; ++i) {
             F_mort_mat(i, g) = F_mort_g(i);
             total_F_mort(i) += F_mort_g(i);
@@ -170,18 +293,31 @@ Type objective_function<Type>::operator() ()
 
     vector<Type> mort = mu_mat * pow(w / w_mat, d) + total_F_mort;
 
-    vector<Type> growth = calculate_growth(w, ergr, matur, m, n, w_repro_max);
+    vector<Type> growth = calculate_growth(w, ergr, matur, m, n, w_repro_max, defaults_edition);
 
     // External diffusion rate as a power law d(w) = D_ext * w^(n+1), matching
     // the model's `ext_diffusion` slot (getDiffusion()) when use_predation_diffusion
     // is FALSE.
     Type D_ext = exp(log_D_ext);
     vector<Type> d_diff(n_bins);
-    for (int i = 0; i < n_bins; ++i) {
-        d_diff(i) = D_ext * pow(w(i), n + Type(1.0));
+    if (second_order == 1) {
+        Type d_exp = n + Type(1.0);
+        for (int i = 0; i < n_bins; ++i) {
+            Type w_next = w(i) + dw(i);
+            d_diff(i) = D_ext * (pow(w_next, d_exp + Type(1.0)) - pow(w(i), d_exp + Type(1.0))) / ((d_exp + Type(1.0)) * dw(i));
+        }
+    } else {
+        for (int i = 0; i < n_bins; ++i) {
+            d_diff(i) = D_ext * pow(w(i), n + Type(1.0));
+        }
     }
 
-    vector<Type> N = calculate_N(mort, growth, dw, d_diff);
+    vector<Type> N;
+    if (second_order == 1) {
+        N = calculate_N_second_order(mort, growth, dw, w, d_diff, psi);
+    } else {
+        N = calculate_N(mort, growth, dw, d_diff);
+    }
 
     Type unscaled_biomass = 0;
     for (int i = biomass_cutoff_idx; i < n_bins; ++i) {
@@ -202,6 +338,8 @@ Type objective_function<Type>::operator() ()
     model_yield.fill(Type(0.0));
 
     Type nll = Type(0.0);
+    Type multinomial_nll = Type(0.0);
+    Type yield_nll = Type(0.0);
 
     int c_bins = counts.rows();
     int num_segs = bin_index.size();
@@ -219,8 +357,20 @@ Type objective_function<Type>::operator() ()
             vector<Type> dens_per_bin_g = N * F_mort_g;
             catch_per_bin_mat.col(g) = catch_per_bin_g;
             dens_per_bin_mat.col(g) = dens_per_bin_g;
-            vector<Type> model_yield_g = catch_per_bin_g * w;
-            model_yield(g) = model_yield_g.sum();
+            
+            Type model_yield_val = Type(0.0);
+            if (second_order == 1) {
+                for (int i = 0; i < n_bins - 1; ++i) {
+                    Type w_eff = Type(0.5) * (F_mort_g(i) * w(i) + F_mort_g(i+1) * w(i+1));
+                    model_yield_val += N(i) * w_eff * dw(i);
+                }
+                model_yield_val += N(n_bins - 1) * F_mort_g(n_bins - 1) * w(n_bins - 1) * dw(n_bins - 1);
+            } else {
+                for (int i = 0; i < n_bins; ++i) {
+                    model_yield_val += N(i) * F_mort_g(i) * w(i) * dw(i);
+                }
+            }
+            model_yield(g) = model_yield_val;
 
             vector<Type> counts_g(c_bins);
             counts_g.fill(Type(0.0));
@@ -240,10 +390,14 @@ Type objective_function<Type>::operator() ()
 
             probs /= probs.sum();
 
-            nll -= dmultinom(counts_g, probs, true) / counts_g.sum();
+            Type mult_val = -dmultinom(counts_g, probs, true) / counts_g.sum();
+            multinomial_nll += mult_val;
+            nll += mult_val;
 
             if (yield_lambda > 0) {
-                nll += yield_lambda * pow(log(model_yield(g) / yield(g)), Type(2));
+                Type yield_val = yield_lambda * pow(log(model_yield(g) / yield(g)), Type(2));
+                yield_nll += yield_val;
+                nll += yield_val;
             }
 
         }
@@ -263,13 +417,15 @@ Type objective_function<Type>::operator() ()
     //
     // }
 
+    Type production_nll = Type(0.0);
     if (production_lambda > 0) {
         // **Calculate production**
         vector<Type> production_per_bin = N * growth * dw;
         Type model_production = production_per_bin.sum();
         REPORT(model_production);
         // **Add penalty for deviation from observed production**
-        nll += production_lambda * pow(log(model_production / production), Type(2));
+        production_nll = production_lambda * pow(log(model_production / production), Type(2));
+        nll += production_nll;
     }
 
     // Final sanity checks
@@ -286,6 +442,9 @@ Type objective_function<Type>::operator() ()
     REPORT(mort);
     REPORT(growth);
     REPORT(d_diff);
+    REPORT(multinomial_nll);
+    REPORT(yield_nll);
+    REPORT(production_nll);
 
     // Check final biomass again
     Type total_biomass = 0;

--- a/src/objective_function.cpp
+++ b/src/objective_function.cpp
@@ -93,21 +93,21 @@ vector<Type> calculate_growth(vector<Type> w, vector<Type> ergr,
     for (int i = 0; i < repro_prop.size(); i++) {
         if (repro_prop(i) > Type(1.0)) repro_prop(i) = Type(1.0);
     }
-    vector<Type> phi = matur * repro_prop;
-    for (int i = 0; i < phi.size(); i++) {
-        if (phi(i) > Type(1.0)) phi(i) = Type(1.0);
+    vector<Type> psi = matur * repro_prop;
+    for (int i = 0; i < psi.size(); i++) {
+        if (psi(i) > Type(1.0)) psi(i) = Type(1.0);
     }
     
     // Set psi for all w > w_repro_max to 1 if defaults_edition < 2
     if (defaults_edition < 2) {
         for (int i = 0; i < w.size(); i++) {
             if (w(i) > w_repro_max) {
-                phi(i) = Type(1.0);
+                psi(i) = Type(1.0);
             }
         }
     }
     
-    vector<Type> growth = (Type(1.0) - phi) * ergr;
+    vector<Type> growth = (Type(1.0) - psi) * ergr;
     for (int i = 0; i < growth.size(); i++) {
         if (growth(i) < Type(0.0)) growth(i) = Type(0.0);
     }
@@ -166,7 +166,7 @@ vector<Type> calculate_N(vector<Type> mort, vector<Type> growth,
 
 template<class Type>
 vector<Type> calculate_N_second_order(vector<Type> mort, vector<Type> growth,
-                                      vector<Type> dw, vector<Type> w, vector<Type> d, vector<Type> psi)
+                                      vector<Type> dw, vector<Type> w, vector<Type> d, vector<Type> chi)
 {
     int size = dw.size();
     vector<Type> a(size), b(size), c(size), S(size);
@@ -185,10 +185,10 @@ vector<Type> calculate_N_second_order(vector<Type> mort, vector<Type> growth,
         Type inv_dw = Type(1.0) / dw(j);
         
         Type gj = growth(j);
-        Type psij = psi(j);
+        Type chij = chi(j);
         
         Type gj_plus_1 = (j < size - 1) ? growth(j + 1) : growth(j);
-        Type psij_plus_1 = (j < size - 1) ? psi(j + 1) : Type(0.0);
+        Type chij_plus_1 = (j < size - 1) ? chi(j + 1) : Type(0.0);
         
         Type wj = w(j);
         Type wj_plus_1 = (j < size - 1) ? w(j + 1) : w(j) * beta;
@@ -197,14 +197,14 @@ vector<Type> calculate_N_second_order(vector<Type> mort, vector<Type> growth,
         Type dj_minus_1 = d(j - 1);
         Type dj_plus_1 = (j < size - 1) ? d(j + 1) : d(j);
 
-        a(j) = -inv_dw * (gj * (Type(1.0) - Type(0.5) * psij) + dj_minus_1 / (Type(2.0) * h * wj));
+        a(j) = -inv_dw * (gj * (Type(1.0) - Type(0.5) * chij) + dj_minus_1 / (Type(2.0) * h * wj));
         
-        b(j) = mort(j) + inv_dw * (gj_plus_1 * (Type(1.0) - Type(0.5) * psij_plus_1) 
-                                   - Type(0.5) * psij * gj 
+        b(j) = mort(j) + inv_dw * (gj_plus_1 * (Type(1.0) - Type(0.5) * chij_plus_1) 
+                                   - Type(0.5) * chij * gj 
                                    + dj * (Type(1.0) / (Type(2.0) * h * wj) + Type(1.0) / (Type(2.0) * h * wj_plus_1)));
         
         c(j) = (j < size - 1) ?
-            (inv_dw * (Type(0.5) * psij_plus_1 * gj_plus_1 - dj_plus_1 / (Type(2.0) * h * wj_plus_1))) : Type(0.0);
+            (inv_dw * (Type(0.5) * chij_plus_1 * gj_plus_1 - dj_plus_1 / (Type(2.0) * h * wj_plus_1))) : Type(0.0);
             
         S(j) = Type(0.0);
     }
@@ -255,7 +255,7 @@ Type objective_function<Type>::operator() ()
     DATA_SCALAR(n);
     DATA_SCALAR(w_repro_max);
     DATA_INTEGER(second_order);
-    DATA_VECTOR(psi);
+    DATA_VECTOR(chi);
     DATA_INTEGER(defaults_edition);
     DATA_SCALAR(b_lw);
 
@@ -314,7 +314,7 @@ Type objective_function<Type>::operator() ()
 
     vector<Type> N;
     if (second_order == 1) {
-        N = calculate_N_second_order(mort, growth, dw, w, d_diff, psi);
+        N = calculate_N_second_order(mort, growth, dw, w, d_diff, chi);
     } else {
         N = calculate_N(mort, growth, dw, d_diff);
     }

--- a/tests/testthat/test-matchCatch.R
+++ b/tests/testthat/test-matchCatch.R
@@ -475,3 +475,46 @@ test_that("map argument fixes the specified parameter at its initial value", {
     l50_after <- gear_params(result)[gear_params(result)$species == "Hake", "l50"]
     expect_equal(l50_before, l50_after)
 })
+
+test_that("matchCatch recovers the true parameters when second_order_w is TRUE", {
+    species <- "Haddock"
+    sg <- make_celtic_single_gear()
+    second_order_w(sg) <- TRUE
+    sg <- steadySingleSpecies(sg, species = species)
+    s  <- species_params(sg)$species == species
+    gp0 <- gear_params(sg); gi0 <- which(gp0$species == species)
+    gp0$yield_observed[gi0] <- getYield(sg)[s]
+    gear_params(sg) <- gp0
+    catch <- model_catch_data(sg, species)
+
+    gp_true   <- gear_params(sg)[gear_params(sg)$species == species, ]
+    l50_true  <- gp_true$l50
+    q_true    <- gp_true$catchability
+    mu_true   <- species_params(sg)[s, "mu_mat"]
+    D_true    <- species_params(sg)[s, "D_ext"]
+    prod_true <- getProduction(sg)[species]
+
+    # Start from deliberately wrong values
+    pp <- sg
+    gp <- gear_params(pp); gi <- which(gp$species == species)
+    gp$l50[gi] <- l50_true + 8; gp$l25[gi] <- gp$l50[gi] - 4
+    gp$catchability[gi] <- 1
+    gear_params(pp) <- gp
+    spp <- species_params(pp)
+    spp$mu_mat[s] <- mu_true * 4
+    spp$D_ext[s]  <- D_true / 4
+    spp$production_observed[s] <- prod_true
+    pp@ext_diffusion[s, ] <- spp$D_ext[s] * pp@w^(spp$n[s] + 1)
+    species_params(pp) <- spp
+
+    fit <- suppressWarnings(matchCatch(
+        pp, species = species, catch = catch,
+        yield_lambda = 1, production_lambda = 1, map = list(m = factor(NA))))
+    gp_fit <- gear_params(fit)[gear_params(fit)$species == species, ]
+    sp_fit <- species_params(fit)[s, ]
+
+    expect_equal(gp_fit$l50, l50_true, tolerance = 0.02)
+    expect_equal(gp_fit$catchability, q_true, tolerance = 0.03)
+    expect_equal(sp_fit$mu_mat, mu_true, tolerance = 0.05)
+    expect_equal(sp_fit$D_ext, D_true, tolerance = 0.05)
+})


### PR DESCRIPTION
This pull request extends the matchCatch() parameter estimation system to support the second-order log-size finite-volume scheme (second_order_w = TRUE).